### PR TITLE
`mdget`: Consider replacing `r.jina.ai` with `pure.md`

### DIFF
--- a/bin/mdget
+++ b/bin/mdget
@@ -1,3 +1,3 @@
 #!/bin/bash
 
-curl https://r.jina.ai/$*
+curl https://pure.md/$*


### PR DESCRIPTION
[pure.md](https://pure.md) is a free drop-in replacement for Jina Reader. It's much faster and strips out superfluous fluff -- just compare the output for shopify's marketing site: https://pure.md/compare/?url=https%3A%2F%2Fshopify.com 

It works in the same way, simply prefix any URL with `pure.md/`. HTML, PDFs, images, and spreadsheets are supported. 